### PR TITLE
Adds support for disabling banner in output

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "headless": true,
     "noCache": false,
     "noJavascript": false,
-    "noOnline": false
+    "noOnline": false,
+    "noBanner": false
   },
   "author": "liyanfeng(pod4g)",
   "email": "pod4dop@gmail.com",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -16,10 +16,12 @@ module.exports = class Cli {
     try {
       data = require(filePath)
       if (data) {
-        let { noCache, noJavascript, noOnline } = data
+        let { noBanner, noCache, noJavascript, noOnline } = data
+        data.banner = !noBanner
         data.cache = !noCache
         data.javascript = !noJavascript
         data.online = !noOnline
+        delete data.noBanner
         delete data.noCache
         delete data.noJavascript
         delete data.noOnline
@@ -49,6 +51,7 @@ module.exports = class Cli {
       .option('-u, --useragent <ua>', 'to set the useragent')
       .option('-H, --headless [b]', 'whether to use headless mode (default: true)', this.headless)
       .option('-e, --executablePath <path>', 'use the specified chrome browser')
+      .option('--no-banner', 'disable banner (default: false)')
       .option('--no-cache', 'disable cache (default: false)')
       .option('--no-javascript', 'disable javascript (default: false)')
       .option('--no-online', 'disable network (defalut: false)')
@@ -60,6 +63,7 @@ module.exports = class Cli {
       config,
       headless,
       useragent,
+      banner,
       cache,
       javascript,
       online
@@ -81,6 +85,10 @@ module.exports = class Cli {
       headless = config.headless || _args.headless
     }
 
+    if (banner == null) {
+      banner = config.banner || !_args.banner
+    }
+    
     if (cache == null) {
       cache = config.cache || !_args.noCache
     }
@@ -114,6 +122,7 @@ module.exports = class Cli {
       count,
       headless,
       useragent,
+      banner,
       cache,
       javascript,
       online

--- a/src/output/index.js
+++ b/src/output/index.js
@@ -17,12 +17,26 @@ module.exports = class Outputer {
       afterDOMReadyDownloadTime,
       loadTime
     } = total
-    console.log('\n')
-    console.log(figlet.textSync('Hiper'))
-    console.log('\n')
-    // console.log(`🚀 加载 ${global.__hiper__.url} ${global.__hiper__.count} 次 用时 ${(global.__hiper__.runInterval) / 1000} s`)
-    console.log(`🚀 It takes ${(global.__hiper__.runInterval) / 1000} s to load \`${global.__hiper__.url}\` ${global.__hiper__.count} times`)
-    console.log('\n')
+    if (global.__hiper__.banner) {
+      console.log('\n')
+      console.log(figlet.textSync('Hiper'))
+      console.log('\n')
+      // console.log(`🚀 加载 ${global.__hiper__.url} ${global.__hiper__.count} 次 用时 ${(global.__hiper__.runInterval) / 1000} s`)
+      console.log(`🚀 It takes ${(global.__hiper__.runInterval) / 1000} s to load \`${global.__hiper__.url}\` ${global.__hiper__.count} times`)
+      console.log('\n')
+    }
+    new Line()
+      .padding(2)
+      .column('Run interval', 32)
+      .column(`${(global.__hiper__.runInterval) / 1000} s`, 20, [clc.cyan])
+      .fill()
+      .output()
+    new Line()
+      .padding(2)
+      .column('Total load times', 32)
+      .column(global.__hiper__.count.toString(), 20, [clc.cyan])
+      .fill()
+      .output()
     new Line()
       .padding(2)
       .column('DNS lookup time', 32)
@@ -71,6 +85,8 @@ module.exports = class Outputer {
       .column(loadTime, 20, [clc.cyan])
       .fill()
       .output()
-    console.log('\n')
+    if (global.__hiper__.banner) {
+      console.log('\n')
+    }
   }
 }


### PR DESCRIPTION
I added support for disabling the Hiper vanity banner output that shows with every run by adding a --no-banner option with this pull request.

Example:
`$ hiper --no-banner -n 1 https://www.github.com/`

Which produces this output:
```
  Run interval                    1.642 s                                                                                                           
  Total load times                1                                                                                                                 
  DNS lookup time                 1.00 ms                                                                                                           
  TCP connect time                57.00 ms                                                                                                          
  TTFB                            158.00 ms                                                                                                         
  Download time of the page       25.00 ms                                                                                                          
  After DOM Ready download time   871.00 ms                                                                                                         
  White screen time               486.00 ms                                                                                                         
  DOM Ready time                  489.00 ms                                                                                                         
  Load time                       1.36 s 
```